### PR TITLE
Altered library to match structure of Adafruit_MCP23017

### DIFF
--- a/Adafruit_MCP23008.h
+++ b/Adafruit_MCP23008.h
@@ -11,8 +11,9 @@
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
-#ifndef _ADAFRUIT_MCP23008_H
-#define _ADAFRUIT_MCP23008_H
+#ifndef _ADAFRUIT_MCP23008_H_
+#define _ADAFRUIT_MCP23008_H_
+
 // Don't forget the Wire library
 class Adafruit_MCP23008 {
 public:
@@ -23,13 +24,12 @@ public:
   void digitalWrite(uint8_t p, uint8_t d);
   void pullUp(uint8_t p, uint8_t d);
   uint8_t digitalRead(uint8_t p);
-  uint8_t readGPIO(void);
+
   void writeGPIO(uint8_t);
+  uint8_t readGPIO();
 
  private:
   uint8_t i2caddr;
-  uint8_t read8(uint8_t addr);
-  void write8(uint8_t addr, uint8_t data);
 };
 
 #define MCP23008_ADDRESS 0x20

--- a/README
+++ b/README
@@ -17,3 +17,5 @@ Pins 10 thru 17 are your input/output pins
 Check the datasheet for more info: http://ww1.microchip.com/downloads/en/DeviceDoc/21919b.pdf
 
 Enjoy and send pull requests!
+
+Library rewritten to match Adafruit_MCP23017 library - Chris Rogers

--- a/keywords.txt
+++ b/keywords.txt
@@ -13,7 +13,8 @@ MCP23008	KEYWORD1
 #######################################
 
 pullUp	KEYWORD2
-
+writeGPIO	KEYWORD2
+readGPIO	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Altered library to match structure of Adafruit_MCP23017 library but used
MCP23008 info from MCP23008 datasheet.

Could never get original MCP23008 library to work but had no issues with MCP23017.  Noticed how different they were, so I rewrote the MCP23008 library to match form and function of your MCP23017 library but used MCP23008 datasheet properties.  After rewrite, the MCP23008 library and examples worked perfectly.  Thought this would help out other customers who might be struggling like I was.

Chris Rogers
