### PR TITLE
Added basic interrupt handling

### DIFF
--- a/Adafruit_MCP23008.h
+++ b/Adafruit_MCP23008.h
@@ -32,13 +32,26 @@ public:
   uint8_t readGPIO(void);
   void writeGPIO(uint8_t);
 
+  // Interrupt functions
+  void setInterruptOutPinMode(uint8_t mode);
+  uint8_t readInterrupts();
+  void enableInterrupt(uint8_t pin, int mode=CHANGE);
+  void disableInterrupt(uint8_t pin);
+
  private:
   uint8_t i2caddr;
   uint8_t read8(uint8_t addr);
   void write8(uint8_t addr, uint8_t data);
+
+  uint8_t interruptHandlers[8];
 };
 
 #define MCP23008_ADDRESS 0x20
+
+// Interrupt pin modes
+#define MCP23008_INT_OUT_DRAIN 0x00
+#define MCP23008_INT_OUT_HIGH 0x01
+#define MCP23008_INT_OUT_LOW 0x02
 
 // registers
 #define MCP23008_IODIR 0x00

--- a/examples/interrupt/interrupt.pde
+++ b/examples/interrupt/interrupt.pde
@@ -1,0 +1,36 @@
+#include <Wire.h>
+#include "Adafruit_MCP23008.h"
+
+Adafruit_MCP23008 mcp;
+
+void setup() {
+  Serial.begin(9600);
+
+  mcp.begin();      // use default address 0
+
+  // Set the output pin to HIGH when an interrupt had occured
+  mcp.setInterruptOutPinMode(MCP23008_INT_OUT_HIGH);
+
+  mcp.pinMode(0, INPUT);
+
+  // Enable interrupts for pin 0 of type RISING
+  mcp.enableInterrupt(0, RISING);
+}
+
+
+void loop() {
+  uint8_t validInterrupts = mcp.readInterrupts();
+
+  if (validInterrupts) {
+    // Go through the pins
+    for (int pin=0; pin < 8; pin++) {
+      // If the bit for the pin in validInterrupts is set then we have an interrupt on it
+      if ((validInterrupts >> pin) & 1) {
+        Serial.print("Interrupt on pin: ");
+        Serial.println(pin);
+      }
+    }
+  }
+
+  delay(1);
+}


### PR DESCRIPTION
I modified Adafruit_MCP23008.cpp and Adafruit_MCP23008.h and added functions:

  void setInterruptOutPinMode(uint8_t mode);
  uint8_t readInterrupts();
  void enableInterrupt(uint8_t pin, int mode=CHANGE);
  void disableInterrupt(uint8_t pin);

An int array (private)
uint8_t interruptHandlers[8];

And three defines
// Interrupt pin modes
#define MCP23008_INT_OUT_DRAIN 0x00
#define MCP23008_INT_OUT_HIGH 0x01
#define MCP23008_INT_OUT_LOW 0x02

This adds basic interrupt support with RISING, FALLING, CHANGE types fully implemented.
It adds the ability to set the output type of the interrupt trigger pin to HIGH, LOW, DRAIN

I've only tested with esp8266 but will test with an Arduino as soon as I can get one that's not in use.




