### PR TITLE
Allow setting a different wire implementation and add a setInterrupts method

### DIFF
--- a/Adafruit_MCP23008.cpp
+++ b/Adafruit_MCP23008.cpp
@@ -157,6 +157,10 @@ uint8_t Adafruit_MCP23008::digitalRead(uint8_t p) {
   return (readGPIO() >> p) & 0x1;
 }
 
+void Adafruit_MCP23008::setInterrupts(uint8_t data) {
+  write8(MCP23008_GPINTEN, data);
+}
+
 uint8_t Adafruit_MCP23008::read8(uint8_t addr) {
   m_wire->beginTransmission(MCP23008_ADDRESS | i2caddr);
 #if ARDUINO >= 100

--- a/Adafruit_MCP23008.cpp
+++ b/Adafruit_MCP23008.cpp
@@ -1,13 +1,13 @@
-/*************************************************** 
+/***************************************************
   This is a library for the MCP23008 i2c port expander
 
-  These displays use I2C to communicate, 2 pins are required to  
+  These displays use I2C to communicate, 2 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -15,12 +15,6 @@
  #include "Arduino.h"
 #else
  #include "WProgram.h"
-#endif
-#ifdef __AVR_ATtiny85__
-  #include <TinyWireM.h>
-  #define Wire TinyWireM
-#else
-  #include <Wire.h>
 #endif
 
 #ifdef __AVR
@@ -30,46 +24,53 @@
 #endif
 #include "Adafruit_MCP23008.h"
 
+void Adafruit_MCP23008::setWire(TwoWire *wire) {
+  m_wire = wire;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // RTC_DS1307 implementation
 
 void Adafruit_MCP23008::begin(uint8_t addr) {
+  if (m_wire == nullptr) {
+    m_wire = &Wire;
+  }
+
   if (addr > 7) {
     addr = 7;
   }
   i2caddr = addr;
 
-  Wire.begin();
+  m_wire->begin();
 
   // set defaults!
-  Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
+  m_wire->beginTransmission(MCP23008_ADDRESS | i2caddr);
 #if ARDUINO >= 100
-  Wire.write((byte)MCP23008_IODIR);
-  Wire.write((byte)0xFF);  // all inputs
-  Wire.write((byte)0x00);
-  Wire.write((byte)0x00);
-  Wire.write((byte)0x00);
-  Wire.write((byte)0x00);
-  Wire.write((byte)0x00);
-  Wire.write((byte)0x00);
-  Wire.write((byte)0x00);
-  Wire.write((byte)0x00);
-  Wire.write((byte)0x00);	
+  m_wire->write((byte)MCP23008_IODIR);
+  m_wire->write((byte)0xFF);  // all inputs
+  m_wire->write((byte)0x00);
+  m_wire->write((byte)0x00);
+  m_wire->write((byte)0x00);
+  m_wire->write((byte)0x00);
+  m_wire->write((byte)0x00);
+  m_wire->write((byte)0x00);
+  m_wire->write((byte)0x00);
+  m_wire->write((byte)0x00);
+  m_wire->write((byte)0x00);
 #else
-  Wire.send(MCP23008_IODIR);
-  Wire.send(0xFF);  // all inputs
-  Wire.send(0x00);
-  Wire.send(0x00);
-  Wire.send(0x00);
-  Wire.send(0x00);
-  Wire.send(0x00);
-  Wire.send(0x00);
-  Wire.send(0x00);
-  Wire.send(0x00);
-  Wire.send(0x00);	
+  m_wire->send(MCP23008_IODIR);
+  m_wire->send(0xFF);  // all inputs
+  m_wire->send(0x00);
+  m_wire->send(0x00);
+  m_wire->send(0x00);
+  m_wire->send(0x00);
+  m_wire->send(0x00);
+  m_wire->send(0x00);
+  m_wire->send(0x00);
+  m_wire->send(0x00);
+  m_wire->send(0x00);
 #endif
-  Wire.endTransmission();
+  m_wire->endTransmission();
 
 }
 
@@ -79,17 +80,17 @@ void Adafruit_MCP23008::begin(void) {
 
 void Adafruit_MCP23008::pinMode(uint8_t p, uint8_t d) {
   uint8_t iodir;
-  
+
 
   // only 8 bits!
   if (p > 7)
     return;
-  
+
   iodir = read8(MCP23008_IODIR);
 
   // set the pin and direction
   if (d == INPUT) {
-    iodir |= 1 << p; 
+    iodir |= 1 << p;
   } else {
     iodir &= ~(1 << p);
   }
@@ -99,7 +100,7 @@ void Adafruit_MCP23008::pinMode(uint8_t p, uint8_t d) {
 }
 
 uint8_t Adafruit_MCP23008::readGPIO(void) {
-  // read the current GPIO input 
+  // read the current GPIO input
   return read8(MCP23008_GPIO);
 }
 
@@ -110,7 +111,7 @@ void Adafruit_MCP23008::writeGPIO(uint8_t gpio) {
 
 void Adafruit_MCP23008::digitalWrite(uint8_t p, uint8_t d) {
   uint8_t gpio;
-  
+
   // only 8 bits!
   if (p > 7)
     return;
@@ -120,7 +121,7 @@ void Adafruit_MCP23008::digitalWrite(uint8_t p, uint8_t d) {
 
   // set the pin and direction
   if (d == HIGH) {
-    gpio |= 1 << p; 
+    gpio |= 1 << p;
   } else {
     gpio &= ~(1 << p);
   }
@@ -131,7 +132,7 @@ void Adafruit_MCP23008::digitalWrite(uint8_t p, uint8_t d) {
 
 void Adafruit_MCP23008::pullUp(uint8_t p, uint8_t d) {
   uint8_t gppu;
-  
+
   // only 8 bits!
   if (p > 7)
     return;
@@ -139,7 +140,7 @@ void Adafruit_MCP23008::pullUp(uint8_t p, uint8_t d) {
   gppu = read8(MCP23008_GPPU);
   // set the pin and direction
   if (d == HIGH) {
-    gppu |= 1 << p; 
+    gppu |= 1 << p;
   } else {
     gppu &= ~(1 << p);
   }
@@ -157,31 +158,31 @@ uint8_t Adafruit_MCP23008::digitalRead(uint8_t p) {
 }
 
 uint8_t Adafruit_MCP23008::read8(uint8_t addr) {
-  Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
+  m_wire->beginTransmission(MCP23008_ADDRESS | i2caddr);
 #if ARDUINO >= 100
-  Wire.write((byte)addr);	
+  m_wire->write((byte)addr);
 #else
-  Wire.send(addr);	
+  m_wire->send(addr);
 #endif
-  Wire.endTransmission();
-  Wire.requestFrom(MCP23008_ADDRESS | i2caddr, 1);
+  m_wire->endTransmission();
+  m_wire->requestFrom(MCP23008_ADDRESS | i2caddr, 1);
 
 #if ARDUINO >= 100
-  return Wire.read();
+  return m_wire->read();
 #else
-  return Wire.receive();
+  return m_wire->receive();
 #endif
 }
 
 
 void Adafruit_MCP23008::write8(uint8_t addr, uint8_t data) {
-  Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
+  m_wire->beginTransmission(MCP23008_ADDRESS | i2caddr);
 #if ARDUINO >= 100
-  Wire.write((byte)addr);
-  Wire.write((byte)data);
+  m_wire->write((byte)addr);
+  m_wire->write((byte)data);
 #else
-  Wire.send(addr);	
-  Wire.send(data);
+  m_wire->send(addr);
+  m_wire->send(data);
 #endif
-  Wire.endTransmission();
+  m_wire->endTransmission();
 }

--- a/Adafruit_MCP23008.h
+++ b/Adafruit_MCP23008.h
@@ -31,14 +31,16 @@ public:
   uint8_t digitalRead(uint8_t p);
   uint8_t readGPIO(void);
   void writeGPIO(uint8_t);
+  void setInterrupts(uint8_t data);
 
   void setWire(TwoWire *wire);
 
- private:
+protected:
   uint8_t i2caddr;
   uint8_t read8(uint8_t addr);
   void write8(uint8_t addr, uint8_t data);
 
+private:
   TwoWire *m_wire;
 };
 

--- a/Adafruit_MCP23008.h
+++ b/Adafruit_MCP23008.h
@@ -32,10 +32,14 @@ public:
   uint8_t readGPIO(void);
   void writeGPIO(uint8_t);
 
+  void setWire(TwoWire *wire);
+
  private:
   uint8_t i2caddr;
   uint8_t read8(uint8_t addr);
   void write8(uint8_t addr, uint8_t data);
+
+  TwoWire *m_wire;
 };
 
 #define MCP23008_ADDRESS 0x20


### PR DESCRIPTION
The setWire method allows users to set a different underlying wire mechanism, so long as it inherits from TwoWire from the Wire library. I addressed the concerns pointed out in issue #9 as well, setting the mentioned members to protected and implementing the method mentioned in the issue description.

This has not been tested on hardware but builds in the [project](https://github.com/AllYarnsAreBeautiful/ayab-firmware) I'm working on and the test suite there passes as well. 